### PR TITLE
Use the postgresql repository for RedHat

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -45,6 +45,5 @@
       Environment=PGPORT={{ item.value }}
     create: yes
   with_items: "{{ postgresql_global_config_options }}"
-  when: "{{ item.option == 'port' }}"
+  when: "ansible_distribution_major_version|int > 6 and item.option == 'port'"
   notify: restart postgresql
-  when: ansible_distribution_major_version|int > 6

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -34,6 +34,7 @@
     line: "\\1"
     backrefs: yes
   check_mode: yes #do not modify file, just check PGPORT variable is used
+  when: ansible_distribution_major_version|int > 6
 
 - name: Configure listening port
   blockinfile:
@@ -46,3 +47,4 @@
   with_items: "{{ postgresql_global_config_options }}"
   when: "{{ item.option == 'port' }}"
   notify: restart postgresql
+  when: ansible_distribution_major_version|int > 6

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,12 +1,38 @@
 ---
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+
+- name: Check whether postgresql is installed
+  debug:
+    msg: "{{ ansible_facts.packages['postgresql'] | length }} versions of postgresql are installed!"
+  when: "'postgresql' in ansible_facts.packages"
+
+- name: Remove standard version of PostgreSQL related packages
+  package:
+    name: 
+      - postgresql
+      - postgresql-server
+      - postgresql-contrib
+      - postgresql-libs
+      - postgis
+      - pgbouncer
+    state: absent
+  when: "'postgresql' in ansible_facts.packages and not ansible_facts.packages['postgresql'][0].version.startswith(postgresql_version) "
+
+- name: install PostgreSQL repository
+  package:
+    name: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-redhat-repo-latest.noarch.rpm"
+
 - name: Ensure PostgreSQL packages are installed.
   package:
     name: "{{ postgresql_packages }}"
     state: present
     enablerepo: "{{ postgresql_enablerepo | default(omit, true) }}"
 
-- name: Ensure PostgreSQL Python libraries are installed.
-  package:
-    name: "{{ postgresql_python_library }}"
-    state: present
-    enablerepo: "{{ postgresql_enablerepo | default(omit, true) }}"
+- name: Create a symbolic link to postgres service file
+  ansible.builtin.file:
+    src: /lib/systemd/system/postgresql-{{postgresql_version}}.service
+    dest: /lib/systemd/system/postgresql.service
+    state: link
+  when: ansible_distribution_major_version|int > 6

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,28 +1,31 @@
 ---
-- name: Gather the package facts
-  package_facts:
-    manager: auto
+- name: Install postgresql repository 
+  when: ansible_distribution_major_version|int >= 6 and ansible_distribution_major_version|int <= 8
+  block:
+    - name: Gather the package facts
+      package_facts:
+        manager: auto
 
-- name: Check whether postgresql is installed
-  debug:
-    msg: "{{ ansible_facts.packages['postgresql'] | length }} versions of postgresql are installed!"
-  when: "'postgresql' in ansible_facts.packages"
+    - name: Check whether postgresql is installed
+      debug:
+        msg: "{{ ansible_facts.packages['postgresql'] | length }} versions of postgresql are installed!"
+      when: "'postgresql' in ansible_facts.packages"
 
-- name: Remove standard version of PostgreSQL related packages
-  package:
-    name: 
-      - postgresql
-      - postgresql-server
-      - postgresql-contrib
-      - postgresql-libs
-      - postgis
-      - pgbouncer
-    state: absent
-  when: "'postgresql' in ansible_facts.packages and not ansible_facts.packages['postgresql'][0].version.startswith(postgresql_version) "
+    - name: Remove standard version of PostgreSQL related packages
+      package:
+        name: 
+          - postgresql
+          - postgresql-server
+          - postgresql-contrib
+          - postgresql-libs
+          - postgis
+          - pgbouncer
+        state: absent
+      when: "'postgresql' in ansible_facts.packages and not ansible_facts.packages['postgresql'][0].version.startswith(postgresql_version) "
 
-- name: install PostgreSQL repository
-  package:
-    name: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-redhat-repo-latest.noarch.rpm"
+    - name: install PostgreSQL repository
+      package:
+        name: "https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}/pgdg-redhat-repo-latest.noarch.rpm"
 
 - name: Ensure PostgreSQL packages are installed.
   package:

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,13 +1,13 @@
 ---
 __postgresql_version: "{{postgresql_version | default('9.6') }}"
-__postgresql_version_deb: "{{__postgresql_version | replace('.','')}}"
+__postgresql_version_rh: "{{__postgresql_version | replace('.','')}}"
 __postgresql_data_dir: "/var/lib/pgsql/{{ __postgresql_version }}/data"
 __postgresql_bin_path: "/usr/pgsql-{{ __postgresql_version }}/bin"
 __postgresql_config_path: "/var/lib/pgsql/{{ __postgresql_version }}/data"
 __postgresql_daemon: postgresql-{{ __postgresql_version }}
 __postgresql_packages:
-  - "postgresql{{__postgresql_version_deb}}"
-  - "postgresql{{__postgresql_version_deb}}-server"
-  - "postgresql{{__postgresql_version_deb}}-contrib"
-  - "postgresql{{__postgresql_version_deb}}-libs"
+  - "postgresql{{__postgresql_version_rh}}"
+  - "postgresql{{__postgresql_version_rh}}-server"
+  - "postgresql{{__postgresql_version_rh}}-contrib"
+  - "postgresql{{__postgresql_version_rh}}-libs"
   - libselinux-python

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,12 +1,13 @@
 ---
-__postgresql_version: "9.6"
-__postgresql_data_dir: "/var/lib/pgsql/9.6/data"
-__postgresql_bin_path: "/usr/pgsql-9.6/bin"
-__postgresql_config_path: "/var/lib/pgsql/9.6/data"
-__postgresql_daemon: postgresql-9.6
+__postgresql_version: "{{postgresql_version | default('9.6') }}"
+__postgresql_version_deb: "{{__postgresql_version | replace('.','')}}"
+__postgresql_data_dir: "/var/lib/pgsql/{{ __postgresql_version }}/data"
+__postgresql_bin_path: "/usr/pgsql-{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/var/lib/pgsql/{{ __postgresql_version }}/data"
+__postgresql_daemon: postgresql-{{ __postgresql_version }}
 __postgresql_packages:
-  - postgresql96
-  - postgresql96-server
-  - postgresql96-contrib
-  - postgresql96-libs
+  - "postgresql{{__postgresql_version_deb}}"
+  - "postgresql{{__postgresql_version_deb}}-server"
+  - "postgresql{{__postgresql_version_deb}}-contrib"
+  - "postgresql{{__postgresql_version_deb}}-libs"
   - libselinux-python

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,11 +1,12 @@
 ---
-__postgresql_version: "8.4"
-__postgresql_data_dir: "/var/lib/pgsql/data"
-__postgresql_bin_path: "/usr/bin"
-__postgresql_config_path: "/var/lib/pgsql/data"
-__postgresql_daemon: postgresql
+__postgresql_version: "9.6"
+__postgresql_data_dir: "/var/lib/pgsql/9.6/data"
+__postgresql_bin_path: "/usr/pgsql-9.6/bin"
+__postgresql_config_path: "/var/lib/pgsql/9.6/data"
+__postgresql_daemon: postgresql-9.6
 __postgresql_packages:
-  - postgresql
-  - postgresql-server
-  - postgresql-contrib
-  - postgresql-libs
+  - postgresql96
+  - postgresql96-server
+  - postgresql96-contrib
+  - postgresql96-libs
+  - libselinux-python

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,13 +1,13 @@
 ---
 __postgresql_version: "{{postgresql_version | default('9.6') }}"
-__postgresql_version_deb: "{{__postgresql_version | replace('.','')}}"
+__postgresql_version_rh: "{{__postgresql_version | replace('.','')}}"
 __postgresql_data_dir: "/var/lib/pgsql/{{ __postgresql_version }}/data"
 __postgresql_bin_path: "/usr/pgsql-{{ __postgresql_version }}/bin"
 __postgresql_config_path: "/var/lib/pgsql/{{ __postgresql_version }}/data"
 __postgresql_daemon: postgresql
 __postgresql_packages:
-  - "postgresql{{__postgresql_version_deb}}"
-  - "postgresql{{__postgresql_version_deb}}-server"
-  - "postgresql{{__postgresql_version_deb}}-contrib"
-  - "postgresql{{__postgresql_version_deb}}-libs"
+  - "postgresql{{__postgresql_version_rh}}"
+  - "postgresql{{__postgresql_version_rh}}-server"
+  - "postgresql{{__postgresql_version_rh}}-contrib"
+  - "postgresql{{__postgresql_version_rh}}-libs"
 

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,11 +1,13 @@
 ---
-__postgresql_version: "9.6"
-__postgresql_data_dir: "/var/lib/pgsql/9.6/data"
-__postgresql_bin_path: "/usr/pgsql-9.6/bin"
-__postgresql_config_path: "/var/lib/pgsql/9.6/data"
-__postgresql_daemon: postgresql-9.6
+__postgresql_version: "{{postgresql_version | default('9.6') }}"
+__postgresql_version_deb: "{{__postgresql_version | replace('.','')}}"
+__postgresql_data_dir: "/var/lib/pgsql/{{ __postgresql_version }}/data"
+__postgresql_bin_path: "/usr/pgsql-{{ __postgresql_version }}/bin"
+__postgresql_config_path: "/var/lib/pgsql/{{ __postgresql_version }}/data"
+__postgresql_daemon: postgresql
 __postgresql_packages:
-  - postgresql96
-  - postgresql96-server
-  - postgresql96-contrib
-  - postgresql96-libs
+  - "postgresql{{__postgresql_version_deb}}"
+  - "postgresql{{__postgresql_version_deb}}-server"
+  - "postgresql{{__postgresql_version_deb}}-contrib"
+  - "postgresql{{__postgresql_version_deb}}-libs"
+

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,11 +1,11 @@
 ---
-__postgresql_version: "9.2"
-__postgresql_data_dir: "/var/lib/pgsql/data"
-__postgresql_bin_path: "/usr/bin"
-__postgresql_config_path: "/var/lib/pgsql/data"
-__postgresql_daemon: postgresql
+__postgresql_version: "9.6"
+__postgresql_data_dir: "/var/lib/pgsql/9.6/data"
+__postgresql_bin_path: "/usr/pgsql-9.6/bin"
+__postgresql_config_path: "/var/lib/pgsql/9.6/data"
+__postgresql_daemon: postgresql-9.6
 __postgresql_packages:
-  - postgresql
-  - postgresql-server
-  - postgresql-contrib
-  - postgresql-libs
+  - postgresql96
+  - postgresql96-server
+  - postgresql96-contrib
+  - postgresql96-libs


### PR DESCRIPTION
It's necessary to use the postgresql repository instead of the base repository because the installation of pgbouncer (from another role) causes conflicts. The postgresql repository permits to install newer versions of the application. The default version is now 9.6