### PR TITLE
Uninstall old version of postgres, postgis, pgbouncer on Debian

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,28 @@
 ---
+- name: Install python apt package (global)
+  apt:
+    name: "python-apt" 
+    state: present
+
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+
+- name: Check whether postgresql is installed (Debian)
+  debug:
+    msg: "{{ ansible_facts.packages['postgresql'] | length }} versions of postgresql are installed!"
+  when: "'postgresql' in ansible_facts.packages"
+
+- name: Remove standard version of PostgreSQL related packages (Debian)
+  apt:
+    name: 
+      - postgresql*
+      - postgis*
+      - pgbouncer
+    state: absent
+    autoremove: yes
+  when: "'postgresql' in ansible_facts.packages and not ansible_facts.packages['postgresql'][0].version.startswith(postgresql_version) "
+
 - name: Configure the PostgreSQL APT key (Debian)
   apt_key: 
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,12 +6,12 @@
       package_facts:
         manager: auto
 
-    - name: Check whether postgresql is installed
+    - name: Check whether postgresql is installed (RedHat)
       debug:
         msg: "{{ ansible_facts.packages['postgresql'] | length }} versions of postgresql are installed!"
       when: "'postgresql' in ansible_facts.packages"
 
-    - name: Remove standard version of PostgreSQL related packages
+    - name: Remove standard version of PostgreSQL related packages (RedHat)
       package:
         name: 
           - postgresql


### PR DESCRIPTION
Allow to uninstall the old version of postgres if present in order to install a new version from the postgres repository